### PR TITLE
Added at-support

### DIFF
--- a/lib/SidekiqJobPusher/KeyGenerator.php
+++ b/lib/SidekiqJobPusher/KeyGenerator.php
@@ -4,9 +4,15 @@ namespace SidekiqJobPusher;
 
 class KeyGenerator
 {
-    function generate($queue = 'default', $namespace = null)
+    function generateQueue($queue = 'default', $namespace = null)
     {
         $parts = $this->compact(array($namespace, 'queue', $queue));
+        return implode(':', $parts);
+    }
+
+    public function generateSchedule($namespace = null)
+    {
+        $parts = $this->compact(array($namespace, 'schedule'));
         return implode(':', $parts);
     }
 

--- a/lib/SidekiqJobPusher/MessageSerialiser.php
+++ b/lib/SidekiqJobPusher/MessageSerialiser.php
@@ -4,12 +4,19 @@ namespace SidekiqJobPusher;
 
 class MessageSerialiser
 {
-    function serialise($workerClass, $args = array(), $retry = false)
+    function serialise($workerClass, $args = array(), $retry = false, $queue = 'default')
     {
         return json_encode(array(
+            'jid'   => $this->getId(),
             'class' => $workerClass,
             'args'  => $args,
-            'retry' => $retry
+            'retry' => $retry,
+            'queue' => $queue,
         ));
+    }
+
+    function getId()
+    {
+        return substr(md5(uniqid(mt_rand())), 0, 12);
     }
 }


### PR DESCRIPTION
Sidekiq supports scheduling jobs, by adding them to the sorted set "schedule" with the time to execute as the key.

Added support for scheduling jobs, and added job id to the message.
